### PR TITLE
Fix detecting KeepKey USB device

### DIFF
--- a/libagent/device/keepkey_defs.py
+++ b/libagent/device/keepkey_defs.py
@@ -6,9 +6,16 @@ from keepkeylib.client import CallException, PinException
 from keepkeylib.client import KeepKeyClient as Client
 from keepkeylib.messages_pb2 import PassphraseAck, PinMatrixAck
 from keepkeylib.transport_hid import HidTransport
+from keepkeylib.transport_webusb import WebUsbTransport
 from keepkeylib.types_pb2 import IdentityType
 
 
 def find_device():
-    """Returns first USB HID transport."""
-    return next(HidTransport(p) for p in HidTransport.enumerate())
+    """Returns first WebUSB or HID transport."""
+    webusb = WebUsbTransport.enumerate()
+    hidusb = HidTransport.enumerate()
+
+    if len(webusb):
+        return next(WebUsbTransport(p) for p in webusb)
+    elif len(hidusb):
+        return next(HidTransport(p) for p in hidusb)


### PR DESCRIPTION
The new KeepKey firmware uses WebUSB instead of HID.